### PR TITLE
Can now give chunkToNbt a custom chunk class so it's not tied to only…

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -4,10 +4,10 @@ var Vec3 = require("vec3").Vec3;
 var { readUInt4LE, writeUInt4LE } = require('uint4');
 import nbt from 'prismarine-nbt';
 
-function nbtChunkToPrismarineChunk(data)
+function nbtChunkToPrismarineChunk(data, chunk)
 {
   let nbtd=nbt.simplify(data);
-  const chunk=new Chunk();
+  chunk = chunk || new Chunk();
   readSections(chunk,nbtd.Level.Sections);
   readBiomes(chunk,nbtd.Level.Biomes);
   return chunk;

--- a/test/chunkToNbt.js
+++ b/test/chunkToNbt.js
@@ -18,6 +18,29 @@ for (var x = 0; x < 16;x++) {
 var prismarineChunkToNbt=require('../').chunk("1.8").prismarineChunkToNbt;
 var nbtChunkToPrismarineChunk=require('../').chunk("1.8").nbtChunkToPrismarineChunk;
 
+var MockChunk = function() {};
+MockChunk.prototype = {
+  calledFunctions: {},
+  recordCall: function(functionName){
+    if (!this.calledFunctions[functionName]) {
+      this.calledFunctions[functionName] = 1;
+    }
+    else {
+      this.calledFunctions[functionName]++;
+    }
+  },
+  setBlockType: function(){this.recordCall('setBlockType')},
+  getBlockType: function(){this.recordCall('getBlockType')},
+  setBlockData: function(){this.recordCall('setBlockData')},
+  getBlockData: function(){this.recordCall('getBlockData')},
+  setBlockLight: function(){this.recordCall('setBlockLight')},
+  getBlockLight: function(){this.recordCall('getBlockLight')},
+  setSkyLight: function(){this.recordCall('setSkyLight')},
+  getSkyLight: function(){this.recordCall('getSkyLight')},
+  setBiome: function(){this.recordCall('setBiome')},
+  getBiome: function(){this.recordCall('getBiome')}
+};
+
 describe("transform chunk to nbt",function(){
 
   var nbt=prismarineChunkToNbt(chunk);
@@ -45,5 +68,12 @@ describe("transform chunk to nbt",function(){
     assert.equal(reChunk.getBlockType(new Vec3(0,50,0)),2,"wrong block type at 0,50,0");
     assert.equal(reChunk.getSkyLight(new Vec3(0,50,0)),15);
     assert(bufferEqual(reChunk.dump(),chunk.dump()))
+  });
+
+  it('can read into a provided chunk object', function () {
+    var readChunk = new MockChunk();
+    var nbt2=prismarineChunkToNbt(chunk);
+    readChunk = nbtChunkToPrismarineChunk(nbt2, readChunk);
+    assert.ok(readChunk.calledFunctions.setBlockType > 0, 'custom chunk functions have been called');
   });
 });


### PR DESCRIPTION
… using prismarine chunk objects.

This change makes the code reusable and flexible for other projects.

I'm trying to use this module for my own mapping tool, but I'd like to be able to export the chunk data in a format that I can control rather than having to parse prismarine-chunk data.
This change lets me provide a custom chunk class that matches the prismarine chunk API but can then export the data in a custom format.

I've only made minimal changes and reverts to requiring prismarine-chunk if a custom class is not provided, that way it is still backwards compatible with your other tools.