### PR TITLE
Only store sections between 0 and 16 (block containing sections)

### DIFF
--- a/src/1.14/chunk.js
+++ b/src/1.14/chunk.js
@@ -67,14 +67,14 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
     }
 
     function readSection (chunk, section) {
-      let chunkSection = chunk.sections[section.Y]
-      if (!chunkSection) {
-        chunkSection = new ChunkSection()
-        chunk.sections[section.Y] = chunkSection
-        chunk.sectionMask |= 1 << section.Y
-      }
+      if (section.Y >= 0 && section.Y <= 16) {
+        let chunkSection = chunk.sections[section.Y]
+        if (!chunkSection) {
+          chunkSection = new ChunkSection()
+          chunk.sections[section.Y] = chunkSection
+          chunk.sectionMask |= 1 << section.Y
+        }
 
-      if (section.Y !== -1) {
         readPalette(chunkSection, section.Palette)
         // Empty (filled with air) sections can be stored, but make the client crash if
         // they are sent over. Remove them as soon as possible


### PR DESCRIPTION
Minecraft 1.16 introduced section -1 and 17 which include extra skylight data (but no blockdata), and as such they shouldnt be stored in the block sections