### PR TITLE
Fix error: palette is not iterable

### DIFF
--- a/src/1.14/chunk.js
+++ b/src/1.14/chunk.js
@@ -124,7 +124,7 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
       return 0
     }
 
-    function readPalette (section, palette) {
+    function readPalette (section, palette=[]) {
       section.palette = []
       for (const type of palette) {
         const name = type.Name.split(':')[1]
@@ -140,7 +140,7 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
       }
     }
 
-    function readBlocks (section, blockStates) {
+    function readBlocks (section, blockStates=[]) {
       section.data = section.data.resizeTo(Math.max(4, neededBits(section.palette.length - 1)))
       for (let i = 0; i < blockStates.length; i++) {
         section.data.data[i * 2] = blockStates[i][1] >>> 0


### PR DESCRIPTION
This was first suggested by: https://github.com/PrismarineJS/prismarine-provider-anvil/issues/27#issuecomment-685763195 because using it results in the error mentioned in the title.