### PR TITLE
Write the chunk x and z position like vanilla does

### DIFF
--- a/src/1.13/chunk.js
+++ b/src/1.13/chunk.js
@@ -11,7 +11,7 @@ module.exports = (Chunk, mcData) => {
     return chunk
   }
 
-  function prismarineChunkToNbt (chunk) {
+  function prismarineChunkToNbt (chunk, chunkXPos, chunkZPos) {
     return {
       name: '',
       type: 'compound',
@@ -20,7 +20,15 @@ module.exports = (Chunk, mcData) => {
           type: 'compound',
           value: {
             Biomes: { value: chunk.biomes, type: 'intArray' },
-            Sections: writeSections(chunk)
+            Sections: writeSections(chunk),
+            xPos: {
+              type: 'int',
+              value: chunkXPos
+            },
+            zPos: {
+              type: 'int',
+              value: chunkZPos
+            }
           }
         }
       }

--- a/src/1.14/chunk.js
+++ b/src/1.14/chunk.js
@@ -14,7 +14,7 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
       return chunk
     }
 
-    function prismarineChunkToNbt (chunk) {
+    function prismarineChunkToNbt (chunk, chunkXPos, chunkZPos) {
       return {
         name: '',
         type: 'compound',
@@ -35,6 +35,14 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
               shouldSave: { // Force vanilla server to regenerate missing properties like heightmaps
                 type: 'byte',
                 value: 1
+              },
+              xPos: {
+                type: 'int',
+                value: chunkXPos
+              },
+              zPos: {
+                type: 'int',
+                value: chunkZPos
               }
             }
           },

--- a/src/1.8/chunk.js
+++ b/src/1.8/chunk.js
@@ -11,7 +11,7 @@ module.exports = (Chunk, mcData) => {
     return chunk
   }
 
-  function prismarineChunkToNbt (chunk) {
+  function prismarineChunkToNbt (chunk, chunkXPos, chunkZPos) {
     return {
       name: '',
       type: 'compound',
@@ -20,7 +20,15 @@ module.exports = (Chunk, mcData) => {
           type: 'compound',
           value: {
             Biomes: writeBiomes(chunk),
-            Sections: writeSections(chunk)
+            Sections: writeSections(chunk),
+            xPos: {
+              type: 'int',
+              value: chunkXPos
+            },
+            zPos: {
+              type: 'int',
+              value: chunkZPos
+            }
           }
         }
       }

--- a/src/anvil.js
+++ b/src/anvil.js
@@ -41,7 +41,7 @@ module.exports = (mcVersion) => {
 
     // returns a Promise. Resolve an empty object when successful
     async save (x, z, chunk) {
-      await this.saveRaw(x, z, prismarineChunkToNbt(chunk))
+      await this.saveRaw(x, z, prismarineChunkToNbt(chunk, x, z))
     }
 
     async saveRaw (x, z, nbt) {

--- a/test/chunkToNbt.js
+++ b/test/chunkToNbt.js
@@ -23,11 +23,22 @@ for (const version of testedVersions) {
   const nbtChunkToPrismarineChunk = require('../').chunk(version).nbtChunkToPrismarineChunk
 
   describe('transform chunk to nbt ' + version, function () {
-    const nbt = prismarineChunkToNbt(chunk)
+    const nbt = prismarineChunkToNbt(chunk, 4, 2)
 
     it('write with the correct structure', function () {
       assert.strictEqual(nbt.name, '')
       assert.strictEqual(nbt.type, 'compound')
+    })
+
+    it('write the correct chunk positions', function () {
+      const level = nbt.value.Level
+      assert.strictEqual(level.type, 'compound')
+
+      assert.strictEqual(level.value.xPos.type, 'int')
+      assert.strictEqual(level.value.zPos.type, 'int')
+
+      assert.strictEqual(level.value.xPos.value, 4)
+      assert.strictEqual(level.value.zPos.value, 2)
     })
 
     it('can write biomes', function () {


### PR DESCRIPTION
Vanilla writes the chunks x and z coordinates into the chunks level nbt.
Some tools like mcmap [1] depend on this behavior and fail if the values are missing.

[1]: https://github.com/WRIM/mcmap/blob/86c67ff1482b5090d563a9dfc49f87832b1ffc2b/worldloader.cpp#L358-L359
