### PR TITLE
1.18 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "standard": "^16.0.1"
   },
   "dependencies": {
-    "prismarine-chunk": "^1.25.0",
+    "prismarine-chunk": "^1.29.0",
     "prismarine-nbt": "^2.0.0",
     "uint4": "^0.1.2",
     "vec3": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/",
-    "pretestz": "npm run lint",
+    "pretest": "npm run lint",
     "lint": "standard",
     "fix": "standard --fix"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/",
-    "pretest": "npm run lint",
+    "pretestz": "npm run lint",
     "lint": "standard",
     "fix": "standard --fix"
   },
@@ -30,12 +30,11 @@
     "buffer-equal": "^1.0.0",
     "flatmap": "0.0.3",
     "minecraft-data": "^2.63.0",
-    "mkdirp": "^0.5.1",
     "mocha": "^9.0.0",
+    "prismarine-provider-anvil": "file:.",
+    "prismarine-registry": "^1.1.0",
     "range": "0.0.3",
-    "rimraf": "^3.0.2",
-    "standard": "^16.0.1",
-    "prismarine-provider-anvil": "file:."
+    "standard": "^16.0.1"
   },
   "dependencies": {
     "prismarine-chunk": "^1.25.0",

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -125,13 +125,8 @@ module.exports = (ChunkColumn, registry) => {
     column.inhabitedTime = data.InhabitedTime.valueOf()
 
     for (const section of data.sections) {
-      let bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
-      let bitsPerBiome = Math.ceil(Math.log2(section.biomes.palette.length))
-
-      // Pretend we don't have 0 bpb to make logic simple... 4096 blocks = 4096 bits = 64 i64s
-      // we use arrays of two i32s to represent i64s hence the messy look... So up to someone like nickelpro to optimise :)
-      if (bitsPerBlock === 0) { bitsPerBlock = 1; section.block_states.data = new Array(64).fill([0, 0]) }
-      if (bitsPerBiome === 0) { bitsPerBiome = 1; section.biomes.data = new Array(64).fill([0, 0]) }
+      const bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
+      const bitsPerBiome = Math.ceil(Math.log2(section.biomes.palette.length))
 
       column.loadSection(section.Y, { ...section.block_states, bitsPerBlock }, { ...section.biomes, bitsPerBiome }, section.BlockLight, section.SkyLight)
     }

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -1,0 +1,148 @@
+const assert = require('assert')
+const nbt = require('prismarine-nbt')
+
+nbt.intArray = (value = []) => ({ type: 'intArray', value })
+nbt.byteArray = (value = []) => ({ type: 'byteArray', value })
+nbt.longArray = (value = []) => ({ type: 'longArray', value })
+nbt.bool = (value = false) => ({ type: 'bool', value: value })
+
+module.exports = (ChunkColumn, registry) => {
+  const Block = require('prismarine-block')(registry)
+  const dataVersion = registry.version.dataVersion
+  // turns a JS object into an NBT compound, with the values as nbt.string's
+  const objPropsToNbt = props => Object.fromEntries(Object.entries(props).map(([k, v]) => [k, nbt.string(String(v))]))
+
+  function writeSections (column) {
+    const sections = []
+    const minY = column.minY >> 4
+    const maxY = column.worldHeight >> 4
+    for (let y = minY; y < maxY; y++) {
+      const section = column.sections[y - minY]
+      const biomeSection = column.biomes[y - minY]
+      const blockLightSection = column.blockLightSections[y - minY + 1]
+      const skyLightSection = column.skyLightSections[y - minY + 1]
+
+      if (section) {
+        section.palette ??= [section.data.value]
+        let blockStates, biomes, blockLight, skyLight
+        const blockPalette = section.palette.map(id => Block.fromStateId(id))
+          .map(block => ({
+            Name: nbt.string('minecraft:' + block.name),
+            Properties: nbt.comp(objPropsToNbt(block.getProperties()))
+          }))
+
+        const biomePalette = biomeSection.data.palette ? biomeSection.data.palette : [biomeSection.data.value] // "SingleValue" palette mess
+
+        const bitsPerBlock = Math.ceil(Math.log2(blockPalette.length))
+        const bitsPerBiome = Math.ceil(Math.log2(biomePalette.length))
+
+        if (!bitsPerBlock) {
+          blockStates = nbt.comp({ palette: nbt.list(nbt.comp(blockPalette)) })
+        } else {
+          assert.strictEqual(bitsPerBlock, section.data.data.bitsPerValue, `Computed bits per block for palette size of ${blockPalette.length} (${bitsPerBlock}) does not match bits per block in section, ${section.data.data.bitsPerValue}`)
+
+          const data = section.data.data.toLongArray()
+          blockStates = nbt.comp({ palette: nbt.list(nbt.comp(blockPalette)), data: nbt.longArray(data) })
+        }
+
+        const biomeNamesPalette = biomePalette.map(biomeId => 'minecraft:' + registry.biomes[biomeId].name)
+
+        if (!bitsPerBiome) {
+          biomes = nbt.comp({ palette: nbt.list(nbt.string(biomeNamesPalette)) })
+        } else {
+          assert.strictEqual(bitsPerBiome, biomeSection.data.data.bitsPerValue, `Computed bits per biome for palette size of ${biomeSection?.data?.palette?.length} (${bitsPerBiome}) does not match bits per biome in section ${biomeSection?.data?.data?.bitsPerValue}`)
+
+          const data = biomeSection.data.data.toLongArray()
+          biomes = nbt.comp({ palette: nbt.list(nbt.string(biomeNamesPalette)), data: nbt.longArray(data) })
+        }
+
+        if (blockLightSection) {
+          if (blockLightSection.bitsPerValue === 4) {
+            blockLight = new Int8Array(blockLightSection.data.buffer)
+          } else {
+            blockLight = blockLightSection.resizeTo(4)
+          }
+        }
+
+        if (skyLightSection) {
+          if (skyLightSection.bitsPerValue === 4) {
+            skyLight = new Int8Array(skyLightSection.data.buffer)
+          } else {
+            skyLight = skyLightSection.resizeTo(4)
+          }
+        }
+
+        const tag = {
+          Y: nbt.byte(y),
+          block_states: blockStates,
+          biomes: biomes
+        }
+
+        if (blockLight) tag.BlockLight = nbt.byteArray(blockLight)
+        if (skyLight) tag.SkyLight = nbt.byteArray(skyLight)
+
+        sections.push(tag)
+      }
+    }
+
+    return sections
+  }
+
+  function toNBT (column, x, z) {
+    const tag = nbt.comp({
+      DataVersion: nbt.int(dataVersion),
+      Status: nbt.string('full'),
+      xPos: nbt.int(x),
+      yPos: nbt.int(column.minY >> 4), // Lowest y index
+      zPos: nbt.int(z),
+
+      block_entities: nbt.list(column.blockEntities.length ? nbt.comp(column.blockEntities) : null),
+      LastUpdate: nbt.long(column.lastUpdate ?? [Date.now() & 0xffff, 0]),
+      InhabitedTime: nbt.long(column.inhabitedTime ?? 0),
+      structures: nbt.comp({}),
+
+      Heightmaps: nbt.comp({}),
+      sections: nbt.list(nbt.comp(writeSections(column))),
+
+      isLightOn: nbt.bool(false), // If we computed the lighting already
+
+      block_ticks: nbt.list(),
+      PostProcessing: nbt.list(),
+      fluid_ticks: nbt.list()
+    })
+    require('fs').writeFileSync('bchunk.json', JSON.stringify(nbt.simplify(tag), (k, v) => typeof v === 'bigint' ? v.toString() : v, 2))
+    return tag
+  }
+
+  function fromNBT (tag) {
+    const data = nbt.simplify(tag)
+    const column = new ChunkColumn()
+    assert(data.Status === 'full', 'Chunk is not full')
+
+    column.x = data.xPos
+    column.z = data.zPos
+    column.lastUpdate = data.LastUpdate.valueOf()
+    column.inhabitedTime = data.InhabitedTime.valueOf()
+
+    for (const section of data.sections) {
+      let bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
+      let bitsPerBiome = Math.ceil(Math.log2(section.biomes.palette.length))
+
+      // Pretend we don't have 0 bpb to make logic simple... 4096 blocks = 4096 bits = 64 i64s
+      // we use arrays of two i32s to represent i64s hence the messy look... So up to someone like nickelpro to optimise :)
+      if (bitsPerBlock === 0) { bitsPerBlock = 1; section.block_states.data = new Array(64).fill([0, 0]) }
+      if (bitsPerBiome === 0) { bitsPerBiome = 1; section.biomes.data = new Array(64).fill([0, 0]) }
+
+      column.loadSection(section.Y, { ...section.block_states, bitsPerBlock }, { ...section.biomes, bitsPerBiome }, section.BlockLight, section.SkyLight)
+    }
+
+    column.loadBlockEntities(data.block_entities)
+    // Ignore height map data
+    // Ignore structures (what are these?)
+    // Ignore block_ticks, PostProcessing, FluidTicks
+
+    return column
+  }
+
+  return { nbtChunkToPrismarineChunk: fromNBT, prismarineChunkToNbt: toNBT }
+}

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -96,7 +96,7 @@ module.exports = (ChunkColumn, registry) => {
       yPos: nbt.int(column.minY >> 4), // Lowest y index
       zPos: nbt.int(z),
 
-      block_entities: nbt.list(column.blockEntities.length ? nbt.comp(column.blockEntities) : null),
+      block_entities: nbt.list(Object.keys(column.blockEntities).length ? nbt.comp(Object.values(column.blockEntities)) : null),
       LastUpdate: nbt.long(column.lastUpdate ?? [Date.now() & 0xffff, 0]),
       InhabitedTime: nbt.long(column.inhabitedTime ?? 0),
       structures: nbt.comp({}),

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -125,8 +125,12 @@ module.exports = (ChunkColumn, registry) => {
     column.inhabitedTime = data.InhabitedTime.valueOf()
 
     for (const section of data.sections) {
-      const bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
+      let bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
       const bitsPerBiome = Math.ceil(Math.log2(section.biomes.palette.length))
+
+      if (bitsPerBlock === 1 || bitsPerBlock === 2 || bitsPerBlock === 3) {
+        bitsPerBlock = 4
+      }
 
       column.loadSection(section.Y, { ...section.block_states, bitsPerBlock }, { ...section.biomes, bitsPerBiome }, section.BlockLight, section.SkyLight)
     }

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -135,7 +135,10 @@ module.exports = (ChunkColumn, registry) => {
       column.loadSection(section.Y, { ...section.block_states, bitsPerBlock }, { ...section.biomes, bitsPerBiome }, section.BlockLight, section.SkyLight)
     }
 
-    column.loadBlockEntities(data.block_entities)
+    if (data.block_entities.length) {
+      column.loadBlockEntities(tag.value.block_entities.value.value)
+    }
+
     // Ignore height map data
     // Ignore structures (what are these?)
     // Ignore block_ticks, PostProcessing, FluidTicks

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -23,7 +23,7 @@ module.exports = (ChunkColumn, registry) => {
       const skyLightSection = column.skyLightSections[y - minY + 1]
 
       if (section) {
-        section.palette ??= [section.data.value]
+        section.palette = section.palette !== undefined ? [section.data.value] : section.palette
         let blockStates, biomes, blockLight, skyLight
         const blockPalette = section.palette.map(id => Block.fromStateId(id))
           .map(block => ({

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -23,7 +23,7 @@ module.exports = (ChunkColumn, registry) => {
       const skyLightSection = column.skyLightSections[y - minY + 1]
 
       if (section) {
-        section.palette = section.palette !== undefined ? [section.data.value] : section.palette
+        section.palette = section.palette === undefined ? [section.data.value] : section.palette
         let blockStates, biomes, blockLight, skyLight
         const blockPalette = section.palette.map(id => Block.fromStateId(id))
           .map(block => ({

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -110,7 +110,7 @@ module.exports = (ChunkColumn, registry) => {
       PostProcessing: nbt.list(),
       fluid_ticks: nbt.list()
     })
-    require('fs').writeFileSync('bchunk.json', JSON.stringify(nbt.simplify(tag), (k, v) => typeof v === 'bigint' ? v.toString() : v, 2))
+
     return tag
   }
 

--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -1,11 +1,6 @@
 const assert = require('assert')
 const nbt = require('prismarine-nbt')
 
-nbt.intArray = (value = []) => ({ type: 'intArray', value })
-nbt.byteArray = (value = []) => ({ type: 'byteArray', value })
-nbt.longArray = (value = []) => ({ type: 'longArray', value })
-nbt.bool = (value = false) => ({ type: 'bool', value: value })
-
 module.exports = (ChunkColumn, registry) => {
   const Block = require('prismarine-block')(registry)
   const dataVersion = registry.version.dataVersion

--- a/src/anvil.js
+++ b/src/anvil.js
@@ -41,7 +41,8 @@ module.exports = (mcVersion) => {
 
     // returns a Promise. Resolve an empty object when successful
     async save (x, z, chunk) {
-      await this.saveRaw(x, z, prismarineChunkToNbt(chunk, x, z))
+      const tag = prismarineChunkToNbt(chunk, x, z)
+      await this.saveRaw(x, z, tag)
     }
 
     async saveRaw (x, z, nbt) {
@@ -60,8 +61,12 @@ module.exports = (mcVersion) => {
         }
       }
       const toRet = await Promise.all(chunks)
-      region.file.close()
+      await region.file.close()
       return toRet
+    }
+
+    async close () {
+      return Promise.all(Object.keys(this.regions).map(name => this.regions[name].file.close()))
     }
   }
 

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -1,6 +1,7 @@
-module.exports = (mcVersion) => {
-  const mcData = require('minecraft-data')(mcVersion)
-  const Chunk = require('prismarine-chunk')(mcVersion)
+module.exports = (registryOrVersion) => {
+  const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
+  const mcData = require('minecraft-data')(registry)
+  const Chunk = require('prismarine-chunk')(registry)
 
   const chunkImplementations = {
     1.8: require('./1.8/chunk'),
@@ -16,5 +17,5 @@ module.exports = (mcVersion) => {
     1.18: require('./1.18/chunk')
   }
 
-  return chunkImplementations[mcData.version.majorVersion](Chunk, mcData)
+  return chunkImplementations[mcData.version.majorVersion](Chunk, registry)
 }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -1,6 +1,5 @@
 module.exports = (registryOrVersion) => {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
-  const mcData = require('minecraft-data')(registry)
   const Chunk = require('prismarine-chunk')(registry)
 
   const chunkImplementations = {
@@ -17,5 +16,5 @@ module.exports = (registryOrVersion) => {
     1.18: require('./1.18/chunk')
   }
 
-  return chunkImplementations[mcData.version.majorVersion](Chunk, registry)
+  return chunkImplementations[registry.version.majorVersion](Chunk, registry)
 }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -12,7 +12,9 @@ module.exports = (mcVersion) => {
     1.14: require('./1.14/chunk')('1.14', 1976),
     1.15: require('./1.14/chunk')('1.15', 2230),
     1.16: require('./1.14/chunk')('1.16', 2567, true),
-    1.17: require('./1.14/chunk')('1.17', 2730, true)
+    1.17: require('./1.14/chunk')('1.17', 2730, true),
+    1.18: require('./1.18/chunk')
   }
+
   return chunkImplementations[mcData.version.majorVersion](Chunk, mcData)
 }

--- a/src/region.js
+++ b/src/region.js
@@ -261,7 +261,7 @@ class RegionFile {
 
   async close () {
     await this.file.close()
-  };
+  }
 }
 
 RegionFile.VERSION_GZIP = 1

--- a/test/chunkToNbt.js
+++ b/test/chunkToNbt.js
@@ -2,11 +2,13 @@
 
 const { Vec3 } = require('vec3')
 const assert = require('assert')
+const nbt = require('prismarine-nbt')
 
 const testedVersions = ['1.8', '1.13', '1.14', '1.16', '1.17']
 
 for (const version of testedVersions) {
-  const Chunk = require('prismarine-chunk')(version)
+  const registry = require('prismarine-registry')(version)
+  const Chunk = require('prismarine-chunk')(registry)
   const chunk = new Chunk()
 
   for (let x = 0; x < 16; x++) {
@@ -23,48 +25,48 @@ for (const version of testedVersions) {
   const nbtChunkToPrismarineChunk = require('../').chunk(version).nbtChunkToPrismarineChunk
 
   describe('transform chunk to nbt ' + version, function () {
-    const nbt = prismarineChunkToNbt(chunk, 4, 2)
+    const tag = prismarineChunkToNbt(chunk, 4, 2)
 
     it('write with the correct structure', function () {
-      assert.strictEqual(nbt.name, '')
-      assert.strictEqual(nbt.type, 'compound')
+      assert.strictEqual(tag.name, '')
+      assert.strictEqual(tag.type, 'compound')
     })
 
     it('write the correct chunk positions', function () {
-      const level = nbt.value.Level
-      assert.strictEqual(level.type, 'compound')
-
-      assert.strictEqual(level.value.xPos.type, 'int')
-      assert.strictEqual(level.value.zPos.type, 'int')
-
-      assert.strictEqual(level.value.xPos.value, 4)
-      assert.strictEqual(level.value.zPos.value, 2)
+      // in 1.18+, there is no Level wrapper
+      const level = registry.version['>=']('1.18') ? tag.value : tag.value.Level.value
+      if (level.DataVersion) assert.deepEqual(level.DataVersion, nbt.int(registry.version.dataVersion))
+      assert.deepEqual(level.xPos, nbt.int(4))
+      assert.deepEqual(level.zPos, nbt.int(2))
     })
 
     it('can write biomes', function () {
-      if (version === '1.16' || version === '1.17') {
+      console.log(registry.version)
+      if (registry.version['>=']('1.18')) {
+        // Just check for a valid palette as the other test also checks biomes (which are now in individual 3D sections versus 2D)
+        assert(nbt.simplify(tag).sections[0].biomes.palette.length > 0, 'No biomes were found')
+      } else if (registry.version['>=']('1.16')) {
         for (let y = 0; y < 64; y++) {
           for (let x = 0; x < 4; x++) {
             for (let z = 0; z < 4; z++) {
-              assert(nbt.value.Level.value.Biomes.value[y * 16 + x * 4 + z] === chunk.getBiome(new Vec3(x, y * 4, z)))
+              assert(tag.value.Level.value.Biomes.value[y * 16 + x * 4 + z] === chunk.getBiome(new Vec3(x, y * 4, z)))
             }
           }
         }
       } else {
         for (let z = 0; z < 16; z++) {
           for (let x = 0; x < 16; x++) {
-            assert(nbt.value.Level.value.Biomes.value[z * 16 + x] === chunk.getBiome(new Vec3(x, 0, z)))
+            assert(tag.value.Level.value.Biomes.value[z * 16 + x] === chunk.getBiome(new Vec3(x, 0, z)))
           }
         }
       }
     })
 
-    const bufferEqual = require('buffer-equal')
     it('has internal consistency', function () {
-      const reChunk = nbtChunkToPrismarineChunk(nbt)
+      const reChunk = nbtChunkToPrismarineChunk(tag)
       assert.strictEqual(reChunk.getBlockType(new Vec3(0, 50, 0)), 2, 'wrong block type at 0,50,0')
       assert.strictEqual(reChunk.getSkyLight(new Vec3(0, 50, 0)), 15)
-      assert(bufferEqual(reChunk.dump(), chunk.dump()))
+      assert(reChunk.dump().equals(chunk.dump()))
     })
   })
 }

--- a/test/savingLoading.js
+++ b/test/savingLoading.js
@@ -62,7 +62,7 @@ for (const version of testedVersions) {
 
     describe('in sequence ' + version, async () => {
       fs.rmSync(regionPath, { recursive: true, force: true })
-      fs.mkdirSync(regionPath)
+      fs.mkdirSync(regionPath, { recursive: true, force: true })
 
       it('save the world in sequence', async () => {
         const anvil = new Anvil(regionPath)
@@ -78,7 +78,7 @@ for (const version of testedVersions) {
 
     describe('in parallel ' + version, () => {
       fs.rmSync(regionPath, { recursive: true, force: true })
-      fs.mkdirSync(regionPath)
+      fs.mkdirSync(regionPath, { recursive: true, force: true })
 
       it('save the world in parallel', async () => {
         const anvil = new Anvil(regionPath)


### PR DESCRIPTION
* needs https://github.com/PrismarineJS/prismarine-chunk/pull/162
* support prismarine-registry
* reading/writing (kind of) works, but there is a bug with bits per block between 1 and 3. World looks OK in prismarine-viewer with those chunks removed (ignoring the incorrect grass textures re-used from 1.16) : 
![image](https://user-images.githubusercontent.com/13713600/150083578-6578287e-1ba8-4a8d-8ac7-7c223ba6fab7.png)
