### PR TITLE
Initial support for loading Add data to a block

### DIFF
--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -70,7 +70,7 @@ module.exports = (ChunkColumn, registry) => {
         const tag = {
           Y: nbt.byte(y),
           block_states: blockStates,
-          biomes: biomes
+          biomes
         }
 
         if (blockLight) tag.BlockLight = nbt.byteArray(blockLight)

--- a/src/1.8/chunk.js
+++ b/src/1.8/chunk.js
@@ -83,7 +83,7 @@ module.exports = (Chunk, mcData) => {
     blocks = Buffer.from(blocks)
     for (let index = 0; index < blocks.length; index++) {
       const blockType = blocks.readUInt8(index)
-      const addBlockType = !!add ? readUInt4LE(Buffer.from(add), index / 2) : 0
+      const addBlockType = add ? readUInt4LE(Buffer.from(add), index / 2) : 0
       const pos = indexToPos(index, sectionY)
       chunk.setBlockType(pos, blockType + (addBlockType << 8))
     }

--- a/src/1.8/chunk.js
+++ b/src/1.8/chunk.js
@@ -53,7 +53,7 @@ module.exports = (Chunk, mcData) => {
   }
 
   function readSection (chunk, { Y, Blocks, Add, Data, BlockLight, SkyLight }) {
-    readBlocks(chunk, Y, Blocks)
+    readBlocks(chunk, Y, Blocks, Add)
     readSkyLight(chunk, Y, SkyLight)
     readBlockLight(chunk, Y, BlockLight)
     readData(chunk, Y, Data)
@@ -79,12 +79,13 @@ module.exports = (Chunk, mcData) => {
     return new Vec3(x, sectionY * 16 + y, z)
   }
 
-  function readBlocks (chunk, sectionY, blocks) {
+  function readBlocks (chunk, sectionY, blocks, add) {
     blocks = Buffer.from(blocks)
     for (let index = 0; index < blocks.length; index++) {
       const blockType = blocks.readUInt8(index)
+      const addBlockType = !!add ? readUInt4LE(Buffer.from(add), index / 2) : 0
       const pos = indexToPos(index, sectionY)
-      chunk.setBlockType(pos, blockType)
+      chunk.setBlockType(pos, blockType + (addBlockType << 8))
     }
   }
 


### PR DESCRIPTION
When using Forge mods (before 1.13?) with modded blocks, the block ID becomes split into the Add section.

This commit adds support for reading that block ID fully, even if minecraft-data does not have that block ID stored. However, I'm not sure on how to write it into a buffer, and as a result, this commit is currently incomplete.