### PR TITLE
Fix Biome id saving

### DIFF
--- a/test/chunkToNbt.js
+++ b/test/chunkToNbt.js
@@ -11,7 +11,7 @@ for (const version of testedVersions) {
 
   for (let x = 0; x < 16; x++) {
     for (let z = 0; z < 16; z++) {
-      chunk.setBiome(new Vec3(x, 0, z), 5)
+      chunk.setBiome(new Vec3(x, 0, z), (x + z) % 2 === 0 ? 5 : 137)
       chunk.setBlockType(new Vec3(x, 50, z), 2)
       for (let y = 0; y < 256; y++) {
         chunk.setSkyLight(new Vec3(x, y, z), 15)


### PR DESCRIPTION
Biomes are currently saved with nbt arrays that take numbers between -128 and 127. But biome id's range from 0 to 255. This pr shims the data before being saved to convert the id's. Otherwise saving some chunks might fail due to value out of range errors in prismarine-nbt and protodef.