### PR TITLE
Require chunks impl lazily

### DIFF
--- a/src/chunk.js
+++ b/src/chunk.js
@@ -1,20 +1,29 @@
+const PrismarineChunk = require('prismarine-chunk')
+
 module.exports = (registryOrVersion) => {
   const registry = typeof registryOrVersion === 'string' ? require('prismarine-registry')(registryOrVersion) : registryOrVersion
-  const Chunk = require('prismarine-chunk')(registry)
+  const Chunk = PrismarineChunk(registry)
 
   const chunkImplementations = {
-    1.8: require('./1.8/chunk'),
-    1.9: require('./1.8/chunk'),
-    '1.10': require('./1.8/chunk'),
-    1.11: require('./1.8/chunk'),
-    1.12: require('./1.8/chunk'),
-    1.13: require('./1.13/chunk'),
-    1.14: require('./1.14/chunk')('1.14', 1976),
-    1.15: require('./1.14/chunk')('1.15', 2230),
-    1.16: require('./1.14/chunk')('1.16', 2567, true),
-    1.17: require('./1.14/chunk')('1.17', 2730, true),
-    1.18: require('./1.18/chunk')
+    1.8: () => require('./1.8/chunk'),
+    1.9: () => require('./1.8/chunk'),
+    '1.10': () => require('./1.8/chunk'),
+    1.11: () => require('./1.8/chunk'),
+    1.12: () => require('./1.8/chunk'),
+    1.13: () => require('./1.13/chunk'),
+    1.14: () => require('./1.14/chunk')('1.14', 1976),
+    1.15: () => require('./1.14/chunk')('1.15', 2230),
+    1.16: () => require('./1.14/chunk')('1.16', 2567, true),
+    1.17: () => require('./1.14/chunk')('1.17', 2730, true),
+    1.18: () => require('./1.18/chunk')
   }
 
-  return chunkImplementations[registry.version.majorVersion](Chunk, registry)
+  const loadVersion = registry.version.majorVersion
+  const implementationLoader = chunkImplementations[loadVersion]?.()
+
+  if (!implementationLoader) {
+    throw new Error(`Unsupported version: ${loadVersion}`)
+  }
+
+  return implementationLoader(Chunk, registry)
 }


### PR DESCRIPTION
I'm working on loading needed data for prismarine web client on demand. With current impl all chunks are required which leads to require 1.13 mc data:
https://github.com/PrismarineJS/prismarine-provider-anvil/blob/2d10dfef4a535e53d7b645132ced52f4b19cf5bb/src/1.13/chunk.js#L1-L2