### PR TITLE
Default to biome minecraft:void

### DIFF
--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -40,7 +40,7 @@ module.exports = (ChunkColumn, registry) => {
           blockStates = nbt.comp({ palette: nbt.list(nbt.comp(blockPalette)), data: nbt.longArray(data) })
         }
 
-        const biomeNamesPalette = biomePalette.map(biomeId => 'minecraft:' + registry.biomes[biomeId].name)
+        const biomeNamesPalette = biomePalette.map(biomeId => 'minecraft:' + registry.biomes[biomeId]?.name ?? 'void')
 
         if (!bitsPerBiome) {
           biomes = nbt.comp({ palette: nbt.list(nbt.string(biomeNamesPalette)) })


### PR DESCRIPTION
If a biome cannot be found, such as in the case of custom biomes, it will default to `minecraft:void`. 