### PR TITLE
pc1.14-1.17: Don't read empty sections

### DIFF
--- a/src/1.14/chunk.js
+++ b/src/1.14/chunk.js
@@ -55,7 +55,11 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
     }
 
     function readSections (chunk, sections) {
-      sections.forEach(section => readSection(chunk, section))
+      for (const section of sections) {
+        if (section.Palette) {
+          readSection(chunk, section)
+        }
+      }
     }
 
     function writeSections (chunk) {


### PR DESCRIPTION
Sometimes empty sections only have sky light in them, which causes issues where code expects chunk to be non-empty. 

![image](https://github.com/user-attachments/assets/1aef96e6-fe72-4da8-af34-5ba469f2bc21)

Since there are no blocks to apply the sky light to these sections can be skipped