### PR TITLE
Quick fix for 1.17 masks in 1.14 anvil impl

### DIFF
--- a/src/1.14/chunk.js
+++ b/src/1.14/chunk.js
@@ -6,6 +6,7 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
   const ChunkSection = require('prismarine-chunk')(mcVersion).section
 
   return (Chunk, mcData) => {
+    const newFormat = mcData.supportFeature('newLightingDataFormat') // 1.17+
     function nbtChunkToPrismarineChunk (data) {
       const nbtd = nbt.simplify(data)
       const chunk = new Chunk()
@@ -112,6 +113,17 @@ module.exports = (mcVersion, worldVersion, noSpan) => {
           capacity: 4096
         })
         readByteArray(chunk.skyLightSections[section.Y + 1], section.SkyLight)
+      }
+
+      if (newFormat) {
+        chunk.blockLightMask = new BitArray({ bitsPerValue: 1, capacity: 16 })
+        chunk.skyLightMask = new BitArray({ bitsPerValue: 1, capacity: 16 })
+        chunk.sectionMask = new BitArray({ bitsPerValue: 1, capacity: 16 })
+        for (let i = 0; i < 16; i++) {
+          if (chunk.sections[i]) chunk.sectionMask.set(i, true)
+          if (chunk.blockLightSections[i]) chunk.blockLightMask.set(i, true)
+          if (chunk.skyLightSections[i]) chunk.skyLightMask.set(i, true)
+        }
       }
     }
 


### PR DESCRIPTION
Keep the 1.14 impl for now and just overwrite the mask (previously an integer) to be a BitArray as expected by prismarine-chunk

I agree this should be its own file and work like 1.18 but quicker for now without potentially breaking anything big

Working in flying-squid 1.17

![image](https://github.com/user-attachments/assets/4ca4a593-fa53-4828-a8f3-e936daadbba0)
