### PR TITLE
Test all region files instead of only first one

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "prismarine-chunk": "prismarinejs/prismarine-chunk#fix-pc18-light",
+    "prismarine-chunk": "^1.38.1",
     "prismarine-nbt": "^2.0.0",
     "uint4": "^0.1.2",
     "vec3": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "prismarine-chunk": "^1.29.0",
+    "prismarine-chunk": "prismarinejs/prismarine-chunk#fix-pc18-light",
     "prismarine-nbt": "^2.0.0",
     "uint4": "^0.1.2",
     "vec3": "^0.1.6"

--- a/test/openRegion.js
+++ b/test/openRegion.js
@@ -8,14 +8,19 @@ const testedVersions = prismarineProviderAnvil.testedVersions
 describe('can get chunks from region files', function () {
   this.timeout(5 * 1000)
   for (const version of testedVersions) {
-    it(`works for ${version}`, async () => {
+    describe(`open regions ${version}`, async () => {
       const Anvil = prismarineProviderAnvil.Anvil(version)
       const filePath = path.join(fixtures, version)
       const anvil = new Anvil(filePath)
-      const [, xStr, zStr] = fs.readdirSync(filePath)[0].match(/r\.(-?\d+)\.(-?\d+)\.mca/)
-      const [x, z] = [+xStr, zStr]
-      const chunks = await anvil.getAllChunksInRegion(x, z)
-      assert(chunks.length > 0)
+      const regions = fs.readdirSync(filePath).filter(f => f.match(/r\.(-?\d+)\.(-?\d+)\.mca/))
+      for (const region of regions) {
+        const [, xStr, zStr] = region.match(/r\.(-?\d+)\.(-?\d+)\.mca/)
+        const [x, z] = [+xStr, zStr]
+        it('open region ' + region, async () => {
+          const chunks = (await anvil.getAllChunksInRegion(x, z)).filter(x => x)
+          assert(chunks.length > 0)
+        })
+      }
     })
   }
 })


### PR DESCRIPTION
So we can add more fixtures. Picked from https://github.com/PrismarineJS/prismarine-provider-anvil/pull/79