### PR TITLE
Update chunk.js to fix top section not having block_state's

### DIFF
--- a/src/1.18/chunk.js
+++ b/src/1.18/chunk.js
@@ -116,6 +116,9 @@ module.exports = (ChunkColumn, registry) => {
     column.inhabitedTime = data.InhabitedTime.valueOf()
 
     for (const section of data.sections) {
+      //Skip top section with no block_states
+      if (section.block_states == null) continue;
+
       let bitsPerBlock = Math.ceil(Math.log2(section.block_states.palette.length))
       const bitsPerBiome = Math.ceil(Math.log2(section.biomes.palette.length))
 


### PR DESCRIPTION
I'm not sure if this is version specific, but I had issue with this crashing on certain chunks while trying to access block_state of a section.
![image](https://github.com/user-attachments/assets/142bff32-bb72-479a-9763-e0d734bb85e7)
I noticed indeed, the top Y:20 section doesn't have these, as its outside of build limit.

You can reproduce this in vanilla by building a line up to height limit, saving, and checking
![image](https://github.com/user-attachments/assets/3f3912b0-3f25-462a-9c1a-643009d75aae)

This might not be the best way to solve this, but at least its a start. 