### PR TITLE
Use sync zlib to avoid uncaught async errors

### DIFF
--- a/src/level.js
+++ b/src/level.js
@@ -5,11 +5,7 @@ const zlib = require('zlib')
 
 function write (nbtData, cb) {
   const data = nbt.writeUncompressed(nbtData)
-  try {
-    cb(null, zlib.gzipSync(data))
-  } catch (err) {
-    cb(err)
-  }
+  try { cb(null, zlib.gzipSync(data)) } catch(e) { cb(e) }
 }
 
 const parseAsync = promisify(nbt.parse)

--- a/src/level.js
+++ b/src/level.js
@@ -5,7 +5,7 @@ const zlib = require('zlib')
 
 function write (nbtData, cb) {
   const data = nbt.writeUncompressed(nbtData)
-  try { cb(null, zlib.gzipSync(data)) } catch(e) { cb(e) }
+  try { cb(null, zlib.gzipSync(data)) } catch (e) { cb(e) }
 }
 
 const parseAsync = promisify(nbt.parse)

--- a/src/level.js
+++ b/src/level.js
@@ -5,7 +5,11 @@ const zlib = require('zlib')
 
 function write (nbtData, cb) {
   const data = nbt.writeUncompressed(nbtData)
-  zlib.gzip(data, cb)
+  try {
+    cb(null, zlib.gzipSync(data))
+  } catch (err) {
+    cb(err)
+  }
 }
 
 const parseAsync = promisify(nbt.parse)

--- a/src/region.js
+++ b/src/region.js
@@ -1,11 +1,11 @@
-const { promisify } = require('util')
 const fs = require('fs').promises
 const nbt = require('prismarine-nbt')
 const zlib = require('zlib')
 
-const deflateAsync = promisify(zlib.deflate)
-const gunzipAsync = promisify(zlib.gunzip)
-const inflateAsync = promisify(zlib.inflate)
+// Use sync zlib to avoid uncaught async errors on Node 24
+const deflateAsync = (data) => Promise.resolve(zlib.deflateSync(data))
+const gunzipAsync = (data) => Promise.resolve(zlib.gunzipSync(data))
+const inflateAsync = (data) => Promise.resolve(zlib.inflateSync(data))
 
 function createFilledBuffer (size, value) {
   const b = Buffer.alloc(size)

--- a/src/region.js
+++ b/src/region.js
@@ -1,8 +1,9 @@
+const { promisify } = require('util')
 const fs = require('fs').promises
 const nbt = require('prismarine-nbt')
 const zlib = require('zlib')
 
-// Use sync zlib to avoid uncaught async errors on Node 24
+// Sync zlib to avoid uncaught async errors. See nodejs/node#62325
 const deflateAsync = (data) => Promise.resolve(zlib.deflateSync(data))
 const gunzipAsync = (data) => Promise.resolve(zlib.gunzipSync(data))
 const inflateAsync = (data) => Promise.resolve(zlib.inflateSync(data))

--- a/src/region.js
+++ b/src/region.js
@@ -1,4 +1,3 @@
-const { promisify } = require('util')
 const fs = require('fs').promises
 const nbt = require('prismarine-nbt')
 const zlib = require('zlib')


### PR DESCRIPTION
## Summary
- Replace async zlib (deflate/gunzip/inflate/gzip) with sync versions in region.js and level.js

## Why
Node's async zlib creates C++ handles that can error after JS listeners are removed during teardown, causing uncaught exceptions:
- nodejs/node#62325 — use-after-free when reset() called during write
- nodejs/node#61202 — zlib stream corruption with multiple instances

No performance impact — chunk/level data is processed one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)